### PR TITLE
[Feat] 사용자 카테고리 및 목표 설정 기능 추가

### DIFF
--- a/src/main/java/umc9th_hackathon/daybreak/domain/member/controller/UserSetupController.java
+++ b/src/main/java/umc9th_hackathon/daybreak/domain/member/controller/UserSetupController.java
@@ -2,6 +2,9 @@ package umc9th_hackathon.daybreak.domain.member.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 import umc9th_hackathon.daybreak.domain.member.dto.req.UserSetupRequest;
@@ -17,11 +20,13 @@ public class UserSetupController {
     private final UserSetupService userSetupService;
 
     @PostMapping("/setup")
-    public ApiResponse<?> setup(
-            @RequestHeader("X-MEMBER-ID") Long memberId,
-            @RequestBody @Valid UserSetupRequest request
-    ) {
-        userSetupService.setup(memberId, request);
+    public ApiResponse<?> setup(@RequestBody @Valid UserSetupRequest request) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User principal = (User) authentication.getPrincipal();
+        String email = principal.getUsername(); // JwtTokenProvider에서 subject(email)로 넣어둔 값
+
+        userSetupService.setupByEmail(email, request);
 
         return ApiResponse.onSuccess(
                 GeneralSuccessCode.REQUEST_OK,

--- a/src/main/java/umc9th_hackathon/daybreak/domain/member/controller/UserSetupController.java
+++ b/src/main/java/umc9th_hackathon/daybreak/domain/member/controller/UserSetupController.java
@@ -1,0 +1,31 @@
+package umc9th_hackathon.daybreak.domain.member.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import umc9th_hackathon.daybreak.domain.member.dto.req.UserSetupRequest;
+import umc9th_hackathon.daybreak.domain.member.service.UserSetupService;
+import umc9th_hackathon.daybreak.global.apiPayload.ApiResponse;
+import umc9th_hackathon.daybreak.global.apiPayload.code.GeneralSuccessCode;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserSetupController {
+
+    private final UserSetupService userSetupService;
+
+    @PostMapping("/setup")
+    public ApiResponse<?> setup(
+            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @RequestBody @Valid UserSetupRequest request
+    ) {
+        userSetupService.setup(memberId, request);
+
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.REQUEST_OK,
+                "카테고리와 목표가 설정되었습니다."
+        );
+    }
+}

--- a/src/main/java/umc9th_hackathon/daybreak/domain/member/dto/req/UserSetupRequest.java
+++ b/src/main/java/umc9th_hackathon/daybreak/domain/member/dto/req/UserSetupRequest.java
@@ -1,0 +1,14 @@
+package umc9th_hackathon.daybreak.domain.member.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class UserSetupRequest {
+
+    @NotBlank(message = "category는 필수입니다.")
+    private String category;
+
+    @NotBlank(message = "goal은 필수입니다.")
+    private String goal;
+}

--- a/src/main/java/umc9th_hackathon/daybreak/domain/member/dto/res/UserSetupResponse.java
+++ b/src/main/java/umc9th_hackathon/daybreak/domain/member/dto/res/UserSetupResponse.java
@@ -1,0 +1,10 @@
+package umc9th_hackathon.daybreak.domain.member.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserSetupResponse {
+    private Long missionSelectionId;
+}

--- a/src/main/java/umc9th_hackathon/daybreak/domain/member/service/UserSetupService.java
+++ b/src/main/java/umc9th_hackathon/daybreak/domain/member/service/UserSetupService.java
@@ -10,6 +10,9 @@ import umc9th_hackathon.daybreak.domain.mission.entity.Category;
 import umc9th_hackathon.daybreak.domain.mission.entity.MissionSelection;
 import umc9th_hackathon.daybreak.domain.mission.repository.CategoryRepository;
 import umc9th_hackathon.daybreak.domain.mission.repository.MissionSelectionRepository;
+import umc9th_hackathon.daybreak.global.apiPayload.code.GeneralErrorCode;
+import umc9th_hackathon.daybreak.global.apiPayload.code.MemberErrorCode;
+import umc9th_hackathon.daybreak.global.apiPayload.exception.GeneralException;
 
 @Service
 @RequiredArgsConstructor
@@ -21,12 +24,16 @@ public class UserSetupService {
     private final MissionSelectionRepository missionSelectionRepository;
 
     public void setupByEmail(String email, UserSetupRequest req) {
+
+        //회원 조회 실패 시: 커스텀 예외로 처리 (루이 코멘트 반영)
         Member member = memberRepository.findByEmailAndDeletedAtIsNull(email)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+                .orElseThrow(() -> new GeneralException(MemberErrorCode.MEMBER_NOT_FOUND));
 
+        //카테고리 조회 실패 시: 일단 공통 NOT_FOUND로 처리 (원하면 CategoryErrorCode 따로 만들면 더 좋음)
         Category category = categoryRepository.findByCategoryName(req.getCategory())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다."));
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND));
 
+        // 기존 선택이 있으면 업데이트, 없으면 생성
         MissionSelection selection = missionSelectionRepository
                 .findByMember_MemberId(member.getMemberId())
                 .orElseGet(() -> MissionSelection.create(member, category, req.getGoal()));

--- a/src/main/java/umc9th_hackathon/daybreak/domain/member/service/UserSetupService.java
+++ b/src/main/java/umc9th_hackathon/daybreak/domain/member/service/UserSetupService.java
@@ -20,21 +20,18 @@ public class UserSetupService {
     private final CategoryRepository categoryRepository;
     private final MissionSelectionRepository missionSelectionRepository;
 
-    public void setup(Long memberId, UserSetupRequest req) {
-        Member member = memberRepository.findById(memberId)
+    public void setupByEmail(String email, UserSetupRequest req) {
+        Member member = memberRepository.findByEmailAndDeletedAtIsNull(email)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 
         Category category = categoryRepository.findByCategoryName(req.getCategory())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다."));
 
         MissionSelection selection = missionSelectionRepository
-                .findByMember_MemberId(memberId)
+                .findByMember_MemberId(member.getMemberId())
                 .orElseGet(() -> MissionSelection.create(member, category, req.getGoal()));
 
         selection.updateSelection(category, req.getGoal());
-
         missionSelectionRepository.save(selection);
-
     }
 }
-

--- a/src/main/java/umc9th_hackathon/daybreak/domain/member/service/UserSetupService.java
+++ b/src/main/java/umc9th_hackathon/daybreak/domain/member/service/UserSetupService.java
@@ -1,0 +1,40 @@
+package umc9th_hackathon.daybreak.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc9th_hackathon.daybreak.domain.member.dto.req.UserSetupRequest;
+import umc9th_hackathon.daybreak.domain.member.entity.Member;
+import umc9th_hackathon.daybreak.domain.member.repository.MemberRepository;
+import umc9th_hackathon.daybreak.domain.mission.entity.Category;
+import umc9th_hackathon.daybreak.domain.mission.entity.MissionSelection;
+import umc9th_hackathon.daybreak.domain.mission.repository.CategoryRepository;
+import umc9th_hackathon.daybreak.domain.mission.repository.MissionSelectionRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserSetupService {
+
+    private final MemberRepository memberRepository;
+    private final CategoryRepository categoryRepository;
+    private final MissionSelectionRepository missionSelectionRepository;
+
+    public void setup(Long memberId, UserSetupRequest req) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        Category category = categoryRepository.findByCategoryName(req.getCategory())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다."));
+
+        MissionSelection selection = missionSelectionRepository
+                .findByMember_MemberId(memberId)
+                .orElseGet(() -> MissionSelection.create(member, category, req.getGoal()));
+
+        selection.updateSelection(category, req.getGoal());
+
+        missionSelectionRepository.save(selection);
+
+    }
+}
+

--- a/src/main/java/umc9th_hackathon/daybreak/domain/mission/entity/Category.java
+++ b/src/main/java/umc9th_hackathon/daybreak/domain/mission/entity/Category.java
@@ -1,30 +1,30 @@
-package umc9th_hackathon.daybreak.domain.mission.entity;
+    package umc9th_hackathon.daybreak.domain.mission.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
-import umc9th_hackathon.daybreak.global.entity.BaseEntity;
+    import jakarta.persistence.*;
+    import lombok.*;
+    import umc9th_hackathon.daybreak.global.entity.BaseEntity;
 
-import java.util.ArrayList;
-import java.util.List;
+    import java.util.ArrayList;
+    import java.util.List;
 
-@Entity
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
-@Table(name = "category")
-public class Category extends BaseEntity {
+    @Entity
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @Getter
+    @Table(name = "category")
+    public class Category extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "category_id")
-    private Long categoryId;
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        @Column(name = "category_id")
+        private Long categoryId;
 
-    @Column(name = "category_name", length = 10, nullable = false)
-    private String categoryName;
+        @Column(name = "category_name", length = 10, nullable = false)
+        private String categoryName;
 
 
-    // 연관 관계
-    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<MissionSelection> missionSelections = new ArrayList<>();
-}
+        // 연관 관계
+        @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+        private List<MissionSelection> missionSelections = new ArrayList<>();
+    }

--- a/src/main/java/umc9th_hackathon/daybreak/domain/mission/entity/MissionSelection.java
+++ b/src/main/java/umc9th_hackathon/daybreak/domain/mission/entity/MissionSelection.java
@@ -17,6 +17,7 @@ import java.util.List;
 public class MissionSelection extends BaseEntity {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "mission_selection_id")
     private Long missionSelectionId;
 
@@ -25,16 +26,32 @@ public class MissionSelection extends BaseEntity {
 
     // 연관 관계
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", insertable = false, updatable = false)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id", insertable = false, updatable = false)
+    @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
+    @Builder.Default
     @OneToMany(mappedBy = "missionSelection", cascade = CascadeType.ALL)
     private List<Mission> memberMissions = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "missionSelection", cascade = CascadeType.ALL)
     private List<Plan> plans = new ArrayList<>();
+
+    //변경 메서드
+    public void updateSelection(Category category, String objective) {
+        this.category = category;
+        this.objective = objective;
+    }
+
+    public static MissionSelection create(Member member, Category category, String objective) {
+        return MissionSelection.builder()
+                .member(member)
+                .category(category)
+                .objective(objective)
+                .build();
+    }
 }

--- a/src/main/java/umc9th_hackathon/daybreak/domain/mission/repository/CategoryRepository.java
+++ b/src/main/java/umc9th_hackathon/daybreak/domain/mission/repository/CategoryRepository.java
@@ -1,0 +1,9 @@
+package umc9th_hackathon.daybreak.domain.mission.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc9th_hackathon.daybreak.domain.mission.entity.Category;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    Optional<Category> findByCategoryName(String categoryName);
+}

--- a/src/main/java/umc9th_hackathon/daybreak/domain/mission/repository/MissionSelectionRepository.java
+++ b/src/main/java/umc9th_hackathon/daybreak/domain/mission/repository/MissionSelectionRepository.java
@@ -1,0 +1,10 @@
+package umc9th_hackathon.daybreak.domain.mission.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc9th_hackathon.daybreak.domain.mission.entity.MissionSelection;
+
+public interface MissionSelectionRepository extends JpaRepository<MissionSelection, Long> {
+    Optional<MissionSelection> findByMember_MemberId(Long memberId);
+}
+


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가

---

## ✏️ 작업 내용
- 로그인 사용자에 한해 초기 카테고리 및 목표를 설정할 수 있는 API를 구현함
- Category 조회 및 MissionSelection 생성/갱신 로직을 서비스 계층에 추가함
- 중복 설정 시 기존 MissionSelection을 갱신하도록 처리함

---

## 🔗 관련 이슈
- mission selection entity에 insertable=false, updatable=false 제거하였습니다 (JPA가 FK 컬럼 값을 넣을 수 있게)

---

## 💡 추가 사항

